### PR TITLE
Added translation tags in order details

### DIFF
--- a/Block/Sales/Info/Card.php
+++ b/Block/Sales/Info/Card.php
@@ -96,7 +96,7 @@ class Card extends \Magento\Payment\Block\Info
             $value = $this->getFullTypeName($value);
         }
 
-        return $value;
+        return __($value);
     }
 
     /**

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.","Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1."
+"Download the Boleto", "Download the Boleto"

--- a/i18n/es_AR.csv
+++ b/i18n/es_AR.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de prueba y se deben usar en modo sandbox. Por favor, regrese para completar las credenciales de nuevo."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de Producción y se deben usar en modo Producción. Por favor, regrese para completar las credenciales de nuevo."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Monto mínimo de transacción no permitido para la Bandera elegida. Elija otra Bandera o realice una compra superior a %1."
+"Download the Boleto","Descarga del boleto"

--- a/i18n/es_CL.csv
+++ b/i18n/es_CL.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de prueba y se deben usar en modo sandbox. Por favor, regrese para completar las credenciales de nuevo."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de Producción y se deben usar en modo Producción. Por favor, regrese para completar las credenciales de nuevo."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Monto mínimo de transacción no permitido para la Bandera elegida. Elija otra Bandera o realice una compra superior a %1."
+"Download the Boleto","Descarga del boleto"

--- a/i18n/es_CO.csv
+++ b/i18n/es_CO.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de prueba y se deben usar en modo sandbox. Por favor, regrese para completar las credenciales de nuevo."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de Producción y se deben usar en modo Producción. Por favor, regrese para completar las credenciales de nuevo."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Monto mínimo de transacción no permitido para la Bandera elegida. Elija otra Bandera o realice una compra superior a %1."
+"Download the Boleto","Descarga del boleto"

--- a/i18n/es_MX.csv
+++ b/i18n/es_MX.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de prueba y se deben usar en modo sandbox. Por favor, regrese para completar las credenciales de nuevo."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de Producción y se deben usar en modo Producción. Por favor, regrese para completar las credenciales de nuevo."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Monto mínimo de transacción no permitido para la Bandera elegida. Elija otra Bandera o realice una compra superior a %1."
+"Download the Boleto","Descarga del boleto"

--- a/i18n/es_PE.csv
+++ b/i18n/es_PE.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de prueba y se deben usar en modo sandbox. Por favor, regrese para completar las credenciales de nuevo."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de Producción y se deben usar en modo Producción. Por favor, regrese para completar las credenciales de nuevo."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Monto mínimo de transacción no permitido para la Bandera elegida. Elija otra Bandera o realice una compra superior a %1."
+"Download the Boleto","Descarga del boleto"

--- a/i18n/es_UY.csv
+++ b/i18n/es_UY.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de prueba y se deben usar en modo sandbox. Por favor, regrese para completar las credenciales de nuevo."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Sus credenciales son incorrectas. Las credenciales son de Producción y se deben usar en modo Producción. Por favor, regrese para completar las credenciales de nuevo."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Monto mínimo de transacción no permitido para la Bandera elegida. Elija otra Bandera o realice una compra superior a %1."
+"Download the Boleto","Descarga del boleto"

--- a/i18n/pt_BR.csv
+++ b/i18n/pt_BR.csv
@@ -368,3 +368,4 @@ Webpay,Webpay
 "Your credentials are incorrect. Test credentials have been filled in and should be used in sandbox mode. Please check the credentials again.","Suas credenciais estão incorretas. Foram preenchidas credenciais de teste e devem ser usadas no modo sandbox. Por favor verifique as credenciais novamente."
 "Your credentials are incorrect. Production credentials have been filled in and should be used in production mode. Please check the credentials again.","Suas credenciais estão incorretas. Foram preenchidas credenciais de produção e devem ser usadas no modo produção. Por favor verifique as credenciais novamente."
 "Minimum transaction amount not allowed for the chosen brand. Please choose another flag or make a purchase over %1.", "Valor mínimo da transação não permitido para a bandeira escolhida. Por favor escolha outra bandeira ou faça uma compra acima de %1."
+"Download the Boleto","Download do Boleto"

--- a/view/adminhtml/templates/info/twocc/instructions.phtml
+++ b/view/adminhtml/templates/info/twocc/instructions.phtml
@@ -85,13 +85,13 @@ $mpPaymentId = isset($specificInfo['mp_payment_id']) ? $specificInfo['mp_payment
                 <?php if (isset($specificInfo['mp_' . $i . '_status'])) : ?>
                     <tr>
                         <th scope="row"><?= $block->escapeHtml(__('mp_status')); ?>:</th>
-                        <td><?= $block->escapeHtml($specificInfo['mp_' . $i . '_status']) ?></td>
+                        <td><?= $block->escapeHtml(__($specificInfo['mp_' . $i . '_status'])) ?></td>
                     </tr>
                 <?php endif; ?>
                 <?php if (isset($specificInfo['mp_' . $i . '_status_detail'])) : ?>
                     <tr>
                         <th scope="row"><?= $block->escapeHtml(__('mp_status_detail')); ?>:</th>
-                        <td><?= $block->escapeHtml($specificInfo['mp_' . $i . '_status_detail']) ?></td>
+                        <td><?= $block->escapeHtml(__($specificInfo['mp_' . $i . '_status_detail'])) ?></td>
                     </tr>
                 <?php endif; ?>
             <?php endfor; ?>

--- a/view/frontend/templates/info/payment-methods-off/instructions.phtml
+++ b/view/frontend/templates/info/payment-methods-off/instructions.phtml
@@ -96,7 +96,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>
@@ -106,7 +106,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status Detail (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>

--- a/view/frontend/templates/info/pix/instructions.phtml
+++ b/view/frontend/templates/info/pix/instructions.phtml
@@ -101,7 +101,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>
@@ -111,7 +111,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status Detail (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>

--- a/view/frontend/templates/info/pse/instructions.phtml
+++ b/view/frontend/templates/info/pse/instructions.phtml
@@ -92,7 +92,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>
@@ -102,7 +102,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status Detail (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>

--- a/view/frontend/templates/info/webpay/instructions.phtml
+++ b/view/frontend/templates/info/webpay/instructions.phtml
@@ -92,7 +92,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>
@@ -102,7 +102,7 @@ $statusDetail = isset($specificInfo['mp_status_detail']) ? $specificInfo['mp_sta
                                 <?= $block->escapeHtml(__('Status Detail (Mercado Pago)')); ?>
                             </th>
                             <td>
-                                <?= $block->escapeHtml($status) ?>
+                                <?= $block->escapeHtml(__($status)) ?>
                             </td>
                         </tr>
                     <?php endif; ?>


### PR DESCRIPTION
Adicionado tags para reconhecer tradução nos detalhes do pedido de alguns meios de pagamento.

Exemplo
<img width="519" alt="Captura de Tela 2023-05-17 às 18 06 00" src="https://github.com/PluginAndPartners/payment-magento-plugin/assets/61166244/4a7d781e-6907-4a81-bc33-a3fa24d17111">
